### PR TITLE
fix: honor report size in dmarc URI

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,6 +73,12 @@ const validators = {
 					throw new Error(`Invalid value for '${term}': ${value}, must be a list of DMARC URIs such as 'mailto:some.email@somedomain.com'`);
 				}
 				let email = matches[1];
+				const limitRE = /!(.+)$/;
+				const limitMatch = email.match(limitRE);
+				if (limitMatch) {
+					const sizeLimit = limitMatch[0];
+					email = email.replace(sizeLimit, '');
+				}
 				if (!validator.validate(email)) {
 					throw new Error(`Invalid email address in '${term}': '${email}'`);
 				}
@@ -90,6 +96,12 @@ const validators = {
 					throw new Error(`Invalid value for '${term}': ${value}, must be a list of DMARC URIs such as 'mailto:some.email@somedomain.com'`);
 				}
 				let email = matches[1];
+				const limitRE = /!(.+)$/;
+				const limitMatch = email.match(limitRE);
+				if (limitMatch) {
+					const sizeLimit = limitMatch[0];
+					email = email.replace(sizeLimit, '');
+				}
 				if (!validator.validate(email)) {
 					throw new Error(`Invalid email address in '${term}': '${email}'`);
 				}
@@ -157,7 +169,6 @@ function parse(policy) {
 			let settings = validators[validatorTerm];
 
 			// Term matches validaor
-			debugger;
 			let termRegex = new RegExp(`^${validatorTerm}$`, 'i');
 			if (termRegex.test(term)) {
 				found = true;

--- a/test/rua.js
+++ b/test/rua.js
@@ -5,6 +5,10 @@ test('rua with a good email succeeds', t => {
 	t.true(d('v=DMARC1; rua=mailto:word.up@wordup.co').messages === undefined);
 });
 
+test('rua with a good email and report size succeeds', t => {
+	t.true(d('v=DMARC1; rua=mailto:word.up@wordup.co!10m').messages === undefined);
+});
+
 test('rua with bad email fails', t => {
 	let ret = d('v=DMARC1; rua=mailto:bob@bob');
 	// console.log(ret);

--- a/test/ruf.js
+++ b/test/ruf.js
@@ -5,6 +5,10 @@ test('ruf with a good email succeeds', t => {
 	t.true(d('v=DMARC1; ruf=mailto:word.up@wordup.co').messages === undefined);
 });
 
+test('ruf with a good email and report size succeeds', t => {
+	t.true(d('v=DMARC1; ruf=mailto:word.up@wordup.co!10m').messages === undefined);
+});
+
 test('ruf with bad email fails', t => {
 	let ret = d('v=DMARC1; ruf=mailto:bob@bob');
 	// console.log(ret);


### PR DESCRIPTION
Taking a stab at #2 

Honor the report size in dmarc URI (e.g. `... rua=some@email.com!30m`) before validating the email.

closes #2 